### PR TITLE
[Feature] Add Publish Wiki Pipeline

### DIFF
--- a/Pipelines/publish_wiki.yml
+++ b/Pipelines/publish_wiki.yml
@@ -1,0 +1,53 @@
+parameters:
+- name: 'USER_NAME'
+  type: string
+- name: 'USER_EMAIL'
+  type: string
+- name: 'USER_TOKEN'
+  type: string
+
+jobs:
+- job: publish_wiki
+  timeoutInMinutes: 1
+  displayName: Publish Wiki
+
+  pool:
+    vmImage: 'ubuntu-latest'
+
+  variables:
+    - name: 'TEMP_CLONE_WIKI_FOLDER'
+      value: tmp_wiki
+    - name: 'WIKI_FOLDER'
+      value: .github/wiki
+    - group: 'iOS Pipelines'
+
+  steps:
+    # This step will
+    # - Create folder named `tmp_wiki`
+    # - Initialize Git
+    # - Pull old Wiki content
+    - bash: |
+        mkdir $(TEMP_CLONE_WIKI_FOLDER)
+        cd $(TEMP_CLONE_WIKI_FOLDER)
+        git init
+        git config user.name $USER_NAME
+        git config user.email $USER_EMAIL
+        git pull https://$USER_TOKEN@github.com/$(Build.Repository.Name).wiki.git
+      env:
+        USER_NAME: ${{ parameters.USER_NAME }}
+        USER_EMAIL: ${{ parameters.USER_EMAIL }}
+        USER_TOKEN: ${{ parameters.USER_TOKEN }}
+      displayName: Pull current wiki content
+
+    # This step will
+    # - Synchronize differences between `.github/wiki/` & `tmp_wiki`
+    # - Push new Wiki content
+    - bash: |
+        rsync -av --delete $(WIKI_FOLDER)/ $(TEMP_CLONE_WIKI_FOLDER)/ --exclude .git
+        cd $(TEMP_CLONE_WIKI_FOLDER)
+        git add .
+        git commit -m "Update Wiki content"
+        git push -f --set-upstream https://$USER_TOKEN@github.com/$(Build.Repository.Name).wiki.git master
+      env:
+        USER_TOKEN: ${{ parameters.USER_TOKEN }}
+      displayName: Push new wiki content

--- a/Pipelines/publish_wiki.yml
+++ b/Pipelines/publish_wiki.yml
@@ -19,7 +19,6 @@ jobs:
       value: tmp_wiki
     - name: 'WIKI_FOLDER'
       value: .github/wiki
-    - group: 'iOS Pipelines'
 
   steps:
     # This step will

--- a/Pipelines/publish_wiki.yml
+++ b/Pipelines/publish_wiki.yml
@@ -8,7 +8,7 @@ parameters:
 
 jobs:
 - job: publish_wiki
-  timeoutInMinutes: 1
+  timeoutInMinutes: 5
   displayName: Publish Wiki
 
   pool:


### PR DESCRIPTION
## What happened 👀

Add Publish Wiki Pipeline.

## Insight 📝

- Port of https://github.com/nimblehq/github-actions-workflows/blob/develop/.github/workflows/publish_wiki.yml for Azure Pipeline
- Usage
```
trigger: 
- develop
pr: none

variables:
  - group: 'iOS Pipelines'

resources:
  repositories:
    - repository: push_wiki_template
      type: github
      name: nimblehq/azure-pipelines
      ref: refs/heads/feature/publish-wiki # Don't need this block after this PR merge to main.
      endpoint: nimblehq

jobs:
- template: Pipelines/publish_wiki.yml@push_wiki_template
  parameters:
    USER_NAME: $(WIKI_USER_NAME)
    USER_EMAIL: $(WIKI_USER_EMAIL)
    USER_TOKEN: $(DANGER_GITHUB_API_TOKEN)
```

- echo any secret values will show `***`.

## Proof Of Work 📹

<img width="789" alt="Screen Shot 2023-02-06 at 14 10 34" src="https://user-images.githubusercontent.com/6356137/216907057-958b34e8-4a54-4ab6-a0dc-acb4a1a4213f.png">

https://dev.azure.com/nimble-co/Gulf%20Energy%20Approval%20Plus/_build/results?buildId=456&view=logs&j=abe61676-3a0c-577e-84bd-dbfe317cbf0b&t=b33b090f-58c2-5dce-66a0-93f152bb1158